### PR TITLE
Fix duplicate import react-redux

### DIFF
--- a/src/containers/Root.js
+++ b/src/containers/Root.js
@@ -1,9 +1,8 @@
 import React, { PropTypes } from 'react'
-import { Provider } from 'react-redux'
+import { Provider, connect } from 'react-redux'
 import { Router } from 'react-router'
 import { IntlProvider } from 'react-intl'
 import * as messages from 'i18n/'
-import { connect } from 'react-redux'
 
 class Root extends React.Component {
   static propTypes = {


### PR DESCRIPTION
When I run `npm start` and I got this:

src/containers/Root.js
6:1  error  'react-redux' import is duplicated  no-duplicate-imports

✖ 1 problem (1 error, 0 warnings)

So, I fixed it.