### PR TITLE
Fix error when run lint commands:

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,8 @@ node_modules/**
 dist/**
 *.spec.js
 src/index.html
+server/**
+!server/main.js
+build/**
+interfaces/**
+bin/**

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "clean": "rimraf dist",
     "compile": "better-npm-run compile",
-    "lint": "eslint .",
-    "lint:fix": "npm run lint -- --fix",
+    "lint": "eslint .; exit 0;",
+    "lint:fix": "eslint . --fix; exit 0;",
     "start": "better-npm-run start",
     "dev": "better-npm-run dev",
     "dev:nw": "npm run dev -- --nw",


### PR DESCRIPTION
Fix errors when run these lint commands:
1. npm run lint
2. npm run lint:fix

Lint should not check in node_modules directory.
**Error message detail:**
Cannot read property 'value' of undefined
TypeError: Cannot read property 'value' of undefined
    at getStarToken (/home/sinh/try/react-redux-i18n-starter-kit/node_modules/eslint/lib/rules/generator-star-spacing.js:68:25)
    at EventEmitter.checkFunction (/home/sinh/try/react-redux-i18n-starter-kit/node_modules/eslint/lib/rules/generator-star-spacing.js:128:29)
    at emitOne (events.js:101:20)
    at EventEmitter.emit (events.js:188:7)
    at NodeEventGenerator.enterNode (/home/sinh/try/react-redux-i18n-starter-kit/node_modules/eslint/lib/util/node-event-generator.js:40:22)
    at CodePathAnalyzer.enterNode (/home/sinh/try/react-redux-i18n-starter-kit/node_modules/eslint/lib/code-path-analysis/code-path-analyzer.js:608:23)
    at CommentEventGenerator.enterNode (/home/sinh/try/react-redux-i18n-starter-kit/node_modules/eslint/lib/util/comment-event-generator.js:97:23)
    at Controller.enter (/home/sinh/try/react-redux-i18n-starter-kit/node_modules/eslint/lib/eslint.js:925:36)
    at Controller.__execute (/home/sinh/try/react-redux-i18n-starter-kit/node_modules/eslint/node_modules/estraverse/estraverse.js:397:31)
    at Controller.traverse (/home/sinh/try/react-redux-i18n-starter-kit/node_modules/eslint/node_modules/estraverse/estraverse.js:501:28)

npm ERR! Linux 4.4.0-21-generic
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "run" "lint"
npm ERR! node v6.9.1
npm ERR! npm  v3.10.8
npm ERR! code ELIFECYCLE
npm ERR! react-redux-starter-kit@2.0.0-alpha.2 lint: `eslint .`
npm ERR! Exit status 1